### PR TITLE
Some improvements to wordcount function

### DIFF
--- a/nanobot.js
+++ b/nanobot.js
@@ -222,7 +222,9 @@ var WordWar = boo.Base.derive({
 
       if(this.trailing)
       {
-        this.finals.push(sender.name)
+        if (this.finals.indexOf(sender.name) === -1) {
+          this.finals.push(sender.name)
+        }
       }
 
       return 'Sua contagem inicial é de ' + this.wordcounts[sender.name].start +

--- a/nanobot.js
+++ b/nanobot.js
@@ -176,7 +176,7 @@ var WordWar = boo.Base.derive({
 
 , notify_end:
   function _notify_end() {
-    return spice('WordWar acabou, {:participants}.'
+    return spice('WordWar acabou, {:participants}. Enviem sua contagem final com "!wc".'
                 , { participants: this.participants.join(', ') })
   }
 
@@ -401,7 +401,7 @@ NanoBot.prototype.stop_ww = function(cx, text) {
   if (!ensure_not_active(this, cx))  return
 
   this.current_ww.stop()
-  cx.channel.send_reply(cx.sender, "WordWar terminou. As contagens finais podem ser enviadas nos próximos " + (finalWcInterval / 60000) + ' minutos')
+  cx.channel.send_reply(cx.sender, this.current_ww.notify_end())
 
   this.current_ww.trailing_timer = setTimeout(select_winner, finalWcInterval, this.current_ww, cx);
 

--- a/nanobot.js
+++ b/nanobot.js
@@ -408,7 +408,7 @@ NanoBot.prototype.join_ww = function(cx, text) {
     return cx.channel.send_reply(cx.sender, "Você já está participando.")
 
   this.current_ww.join(cx.sender)
-  cx.channel.send(cx.sender + " agora está participando da WordWar. Envie !wc para definir sua contagem de palavras.")
+  cx.channel.send(cx.sender + ' agora está participando da WordWar. Envie "!wc inicial" para definir sua contagem de palavras.')
 }
 
 NanoBot.prototype.part_ww = function(cx, text) {

--- a/nanobot.js
+++ b/nanobot.js
@@ -142,6 +142,7 @@ var WordWar = boo.Base.derive({
   function _part(name) {
     this.participants = this.participants.filter(function(a){ return a !== name.name })
     delete this.wordcounts[name.name]
+    delete this.finals[name.name]
   }
 
 , is_participating:
@@ -209,6 +210,9 @@ var WordWar = boo.Base.derive({
     else if (starting)
     {
       this.wordcounts[sender.name].start = wc;
+      if (this.wordcounts[sender.name].current < wc) {
+        this.wordcounts[sender.name].current = wc;
+      }
       var count = this.wordcounts[sender.name].current - this.wordcounts[sender.name].start
       return 'Sua contagem inicial agora é de ' + wc + ' palavras. Você escreveu então ' + count + ' palavras.'
     }
@@ -416,6 +420,9 @@ NanoBot.prototype.part_ww = function(cx, text) {
   if (this.current_ww.is_participating(cx.sender)) {
     this.current_ww.part(cx.sender)
     cx.channel.send(cx.sender + " deixou de participar da WordWar")
+    if (this.current_ww.finals.length == this.current_ww.participants.length) {
+      return this.end_ww(cx);
+    }
   }
 }
 

--- a/nanobot.js
+++ b/nanobot.js
@@ -243,6 +243,12 @@ var WordWar = boo.Base.derive({
           , total : current - initial
         })
   }
+, blame:
+  function _blame() {
+    return this.participants.filter(function(name) {
+      return this.finals.indexOf(name) === -1;
+    }, this).join(', ');
+  }
 })
 
 
@@ -296,6 +302,11 @@ NanoBot.prototype.init = function() {
   this.register_command("end", this.end_ww, {
     allow_intentions: false,
     help: 'Encerra o envio das contagens imediatamente. Útil para o caso de alguém ter saído do chat no meio da WordWar. Comando: !end'
+  })
+
+  this.register_command("blame", this.blame_wc, {
+    allow_intentions: true,
+    help: 'Mostra quem ainda não enviou a contagem de palavras final. Comando: !blame'
   })
 
   this.register_command("learn", shared.learn, {
@@ -463,6 +474,16 @@ NanoBot.prototype.update_wc = function(cx, text) {
 
   if(this.current_ww.finals.length == this.current_ww.participants.length)
     return this.end_ww(cx)
+}
+
+NanoBot.prototype.blame_wc = function(cx, text) {
+  if (!ensure_not_active(this, cx)) return;
+
+  if (!this.current_ww.trailing) {
+    return cx.channel.send_reply(cx.sender, 'Calma, a WordWar ainda não acabou.');
+  }
+
+  cx.channel.send_reply(cx.intent, 'Os seguintes nanowriters ainda não enviaram a contagem: ' + this.current_ww.blame());
 }
 
 NanoBot.prototype.help = function(cx, text) {


### PR DESCRIPTION
* Add `!blame` command to show who still didn't set the final wordcount.
* Fix a bug in which users were being added the the finals array multiple times.
* Change message on forced stop to be the same as the timer's stop.